### PR TITLE
Remove -r conflict between Ward scraping and resume scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ New: Now scrapes Ward(Worm 2)!
 
 All you'll need is npm and node. Run:
 
-`git clone https:://github.com/nicohman/reimagined-wildbow-scraper.git && cd reimagined-wildbow-scraper`
+`git clone https://github.com/nicohman/reimagined-wildbow-scraper.git`
+
+`cd reimagined-wildbow-scraper`
 
 `npm install`
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You might want to add an alias such as `alias riws = node ~/reimagined-wildbow-s
 ```
     -V, --version         output the version number
     -r , --resume <json>  Resume from JSON file
-    -r, --ward            Scrape Ward
+    -a, --ward            Scrape Ward
     -w, --worm            Scrape Worm
     -t, --twig            Scrape Twig
     -p, --pact            Scrape Pact

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@
 var https = require('follow-redirects').https;
 var program = require("commander");
 var fs = require('fs');
-program.version('0.0.1').option("-r , --resume <json>", "Resume from JSON file").option("-r, --ward", "Scrape Ward").option('-w, --worm', "Scrape Worm").option("-t, --twig", "Scrape Twig").option("-p, --pact", "Scrape Pact").option("-g, --glow_worm", "Scrape Worm 2 Prologue").parse(process.argv);
+program.version('0.0.1').option("-r , --resume <json>", "Resume from JSON file").option("-a, --ward", "Scrape Ward").option('-w, --worm', "Scrape Worm").option("-t, --twig", "Scrape Twig").option("-p, --pact", "Scrape Pact").option("-g, --glow_worm", "Scrape Worm 2 Prologue").parse(process.argv);
 var cheerio = require('cheerio');
 var Epub = require("epub-gen");
 const url = require('url')
@@ -51,9 +51,9 @@ var books = {
         content: []
     },
     glow_worm:{
-    	title:"Glow-worm",
-	author: "John McCrae",
-	content:[]
+        title:"Glow-worm",
+	    author: "John McCrae",
+	    content:[]
     },
     ward:{
        title:"Ward",


### PR DESCRIPTION
Currently if you run `node app.js -r`, given in the docs as a way to scrape Ward, it'll complain about not having enough arguments, since that's also the "resume scraping" option. I changed the Ward scraping option to `-a` to avoid this conflict, and updated the readme to reflect this.

I also fixed a malformed clone URL in the readme.